### PR TITLE
Separate detection from action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.swp
 *~
 .DS_Store
+*.pcap
+tags

--- a/bessctl/conf/ntf.bess
+++ b/bessctl/conf/ntf.bess
@@ -6,7 +6,7 @@ pcap_file = "/opt/ntf/pcap-samples/network-token-sample.pcap"
 
 ntf::NTF()
 ntf.table_create(dpid=1, max_entries=5)
-ntf.entry_create(dpid=1, dscp=0x1a, token={
+ntf.entry_create(dpid=1, dscp=0x1a, rule_id=0xbeefb00f, token={
   'app_id': 0x10001,
   'encryption_key': '{"alg":"A128CBC-HS256","k":"Qr_XwDGctna3SlR88rEJYt6Zm100SASYeJWSJihDnsA","kty":"oct"}'
 })

--- a/bessctl/conf/ntf.bess
+++ b/bessctl/conf/ntf.bess
@@ -6,8 +6,8 @@ pcap_file = "/opt/ntf/pcap-samples/network-token-sample.pcap"
 
 ntf::NTF()
 ntf.table_create(dpid=1, max_entries=5)
-ntf.entry_create(dpid=1, dscp=1, token={
-  'app_id': 0xB00F,
+ntf.entry_create(dpid=1, dscp=0x1a, token={
+  'app_id': 0x10001,
   'encryption_key': '{"alg":"A128CBC-HS256","k":"Qr_XwDGctna3SlR88rEJYt6Zm100SASYeJWSJihDnsA","kty":"oct"}'
 })
 

--- a/modules/ntf.cc
+++ b/modules/ntf.cc
@@ -338,8 +338,8 @@ void NTF::SetDscpMarking(bess::Packet *pkt, uint8_t dscp) {
 }
 
 void NTF::UpdateAuthoritativeDscpMarkings() {
-    using TokenTable = bess::utils::CuckooMap<uint32_t, UserCentricNetworkTokenEntry>;
-    // go over all entries and add all dscp actions to the authoritative list.
+    // Go over all entries and add all dscp actions to the authoritative list.
+    authoritative_dscp_markings.clear();
     for (TokenTable::iterator it=tokenMap_.begin(); it!=tokenMap_.end(); ++it) {
         authoritative_dscp_markings.insert(it->second.dscp);
     }

--- a/modules/ntf.cc
+++ b/modules/ntf.cc
@@ -204,8 +204,11 @@ FlowId NTF::GetFlowId(bess::Packet *pkt) {
     size_t ip_bytes = (ip->header_length) << 2;
 
     Udp *udp = pkt->head_data<Udp *>(sizeof(Ethernet) + ip_bytes);
-    FlowId id = {ip->src.value(), ip->dst.value(), ip->protocol,
-                             udp->src_port.value(), udp->dst_port.value()};
+    FlowId id = {
+        ip->src.value(), ip->dst.value(),
+        udp->src_port.value(), udp->dst_port.value(),
+        ip->protocol
+    };
 
     return id;
 };

--- a/modules/ntf.cc
+++ b/modules/ntf.cc
@@ -42,7 +42,7 @@ CommandResponse
 NTF::Init(const bess::pb::EmptyArg &) {
     using AccessMode = bess::metadata::Attribute::AccessMode;
 
-    LOG(WARNING) << __FUNCTION__;
+    DLOG(WARNING) << __FUNCTION__;
     dpid = 0;
     max_token_entries = 0;
     tokenMap_.Clear();
@@ -55,11 +55,11 @@ NTF::Init(const bess::pb::EmptyArg &) {
 
 CommandResponse
 NTF::CommandTableCreate(const ntf::pb::NtfTableCreateArg &arg) {
-    LOG(WARNING) << __FUNCTION__ << "(dpid=" << arg.dpid() << ", max_entries="
+    DLOG(WARNING) << __FUNCTION__ << "(dpid=" << arg.dpid() << ", max_entries="
                  << arg.max_entries() << ")" ;
 
     if (dpid) {
-        LOG(WARNING) << "Token table with DPID " << dpid <<
+        DLOG(WARNING) << "Token table with DPID " << dpid <<
             " already exists, delete this first to proceed";
         return CommandFailure(-1, "token table already exists, delete this first to proceed");
     }
@@ -74,7 +74,7 @@ NTF::CommandTableCreate(const ntf::pb::NtfTableCreateArg &arg) {
 
 CommandResponse
 NTF::CommandTableDelete(const ntf::pb::NtfTableDeleteArg &arg) {
-    LOG(WARNING) << __FUNCTION__ << "(dpid=" << arg.dpid() << ")";
+    DLOG(WARNING) << __FUNCTION__ << "(dpid=" << arg.dpid() << ")";
 
     if (dpid != arg.dpid() || dpid == 0) {
         return CommandFailure(-1, "invalid DPID value");
@@ -129,7 +129,7 @@ NTF::EntrySet(const T &arg) {
         return CommandFailure(-1, "failed to create new entry");
     }
 
-    LOG(WARNING) << "Entry inserted for 0x" << std::hex << entry.app_id << std::dec;
+    DLOG(WARNING) << "Entry inserted for 0x" << std::hex << entry.app_id << std::dec;
 
     UpdateAuthoritativeDscpMarkings();
     return CommandSuccess();
@@ -179,8 +179,6 @@ CommandResponse
 NTF::CommandEntryDelete(const ntf::pb::NtfEntryDeleteArg &arg) {
     LOG(WARNING) << __FUNCTION__ << "(dpid=" << arg.dpid() << ", app_id="
                  << arg.app_id() << ")";
-
-    LOG(WARNING) << __FUNCTION__;
 
     uint32_t app_id;
 

--- a/modules/ntf.cc
+++ b/modules/ntf.cc
@@ -311,7 +311,10 @@ void NTF::CheckPacketForNetworkToken(Context *ctx, bess::Packet *pkt) {
     }
 
     NtfFlowEntry new_ntf_flow;
-    json_t * _token = nte_decrypt(token->payload.c_str(), hash_item->second.encryption_key.c_str());
+    json_t * _token = nte_decrypt(token->payload.data(),
+                                  token->payload.size(),
+                                  hash_item->second.encryption_key.data(),
+                                  hash_item->second.encryption_key.size());
     if (!_token) {
         DLOG(WARNING) << "NTE Decrypt did not find a valid token";
         return;

--- a/modules/ntf.cc
+++ b/modules/ntf.cc
@@ -37,150 +37,150 @@ const Commands NTF::cmds = {
 
 CommandResponse
 NTF::Init(const bess::pb::EmptyArg &) {
-  LOG(WARNING) << __FUNCTION__;
-  dpid = 0;
-  max_token_entries = 0;
-  tokenMap_.Clear();
-  flowMap_.Clear();
+    LOG(WARNING) << __FUNCTION__;
+    dpid = 0;
+    max_token_entries = 0;
+    tokenMap_.Clear();
+    flowMap_.Clear();
 
-  return CommandSuccess();
+    return CommandSuccess();
 };
 
 CommandResponse
 NTF::CommandTableCreate(const ntf::pb::NtfTableCreateArg &arg) {
-  LOG(WARNING) << __FUNCTION__ << " " << arg.dpid() << arg.max_entries() ;
+    LOG(WARNING) << __FUNCTION__ << " " << arg.dpid() << arg.max_entries() ;
 
-  if (dpid) {
-    LOG(WARNING) << "Token table with DPID " << dpid <<
-      " already exists, delete this first to proceed";
-    return CommandFailure(-1, "token table already exists, delete this first to proceed");
-  }
+    if (dpid) {
+        LOG(WARNING) << "Token table with DPID " << dpid <<
+            " already exists, delete this first to proceed";
+        return CommandFailure(-1, "token table already exists, delete this first to proceed");
+    }
 
-  if (arg.dpid() == 0) {
-    return CommandFailure(-1, "invalid DPID value");
-  }
-  dpid = arg.dpid();
-  max_token_entries = arg.max_entries();
-  return CommandSuccess();
+    if (arg.dpid() == 0) {
+        return CommandFailure(-1, "invalid DPID value");
+    }
+    dpid = arg.dpid();
+    max_token_entries = arg.max_entries();
+    return CommandSuccess();
 };
 
 CommandResponse
 NTF::CommandTableDelete(const ntf::pb::NtfTableDeleteArg &arg) {
-  LOG(WARNING) << __FUNCTION__ << " " << arg.dpid();
+    LOG(WARNING) << __FUNCTION__ << " " << arg.dpid();
 
-  if (dpid != arg.dpid() || dpid == 0) {
-    return CommandFailure(-1, "invalid DPID value");
-  }
+    if (dpid != arg.dpid() || dpid == 0) {
+        return CommandFailure(-1, "invalid DPID value");
+    }
 
-  dpid = 0;
-  max_token_entries = 0;
-  tokenMap_.Clear();
-  return CommandSuccess();
+    dpid = 0;
+    max_token_entries = 0;
+    tokenMap_.Clear();
+    return CommandSuccess();
 };
 
 CommandResponse
 NTF::CommandEntryCreate(const ntf::pb::NtfEntryCreateArg &arg) {
-  LOG(WARNING) << __FUNCTION__;
+    LOG(WARNING) << __FUNCTION__;
 
-  uint32_t app_id;
+    uint32_t app_id;
 
-  if (dpid == 0 || arg.dpid() != dpid) {
-    return CommandFailure(-1, "invalid DPID value");
-  }
+    if (dpid == 0 || arg.dpid() != dpid) {
+        return CommandFailure(-1, "invalid DPID value");
+    }
 
-  app_id = arg.token().app_id();
+    app_id = arg.token().app_id();
 
-  if (tokenMap_.Find(app_id)) {
-    return CommandFailure(-1, "token with app_id already exists --- use entry_modify instead");
-  }
+    if (tokenMap_.Find(app_id)) {
+        return CommandFailure(-1, "token with app_id already exists --- use entry_modify instead");
+    }
 
-  if (tokenMap_.Count() == max_token_entries) {
-    return CommandFailure(-1, "token table is full");
-  }
+    if (tokenMap_.Count() == max_token_entries) {
+        return CommandFailure(-1, "token table is full");
+    }
 
-  UserCentricNetworkTokenEntry entry;
-  entry.app_id = app_id;
-  entry.encryption_key = arg.token().encryption_key();
-  entry.dscp = arg.dscp();
-  for (int i = 0; i < arg.token().blacklist_size(); i++) {
-    entry.blacklist.push_front(arg.token().blacklist(i));
-  }
-  if (!tokenMap_.Insert(entry.app_id, entry)) {
-    return CommandFailure(-1, "failed to create new entry");
-  }
+    UserCentricNetworkTokenEntry entry;
+    entry.app_id = app_id;
+    entry.encryption_key = arg.token().encryption_key();
+    entry.dscp = arg.dscp();
+    for (int i = 0; i < arg.token().blacklist_size(); i++) {
+        entry.blacklist.push_front(arg.token().blacklist(i));
+    }
+    if (!tokenMap_.Insert(entry.app_id, entry)) {
+        return CommandFailure(-1, "failed to create new entry");
+    }
 
-  UpdateAuthoritativeDscpMarkings();
-  return CommandSuccess();
+    UpdateAuthoritativeDscpMarkings();
+    return CommandSuccess();
 };
 
 CommandResponse
 NTF::CommandEntryModify(const ntf::pb::NtfEntryModifyArg &arg) {
-  LOG(WARNING) << __FUNCTION__;
+    LOG(WARNING) << __FUNCTION__;
 
-  uint32_t app_id;
+    uint32_t app_id;
 
-  if (dpid == 0 || arg.dpid() != dpid) {
-    return CommandFailure(-1, "invalid DPID value");
-  }
+    if (dpid == 0 || arg.dpid() != dpid) {
+        return CommandFailure(-1, "invalid DPID value");
+    }
 
-  app_id = arg.token().app_id();
-  if (!tokenMap_.Find(app_id)) {
-    return CommandFailure(-1, "token with app_id doesn't exist --- use entry_create instead");
-  }
+    app_id = arg.token().app_id();
+    if (!tokenMap_.Find(app_id)) {
+        return CommandFailure(-1, "token with app_id doesn't exist --- use entry_create instead");
+    }
 
-  UserCentricNetworkTokenEntry entry;
-  entry.app_id = app_id;
-  entry.encryption_key = arg.token().encryption_key();
-  entry.dscp = arg.dscp();
-  for (int i = 0; i < arg.token().blacklist_size(); i++)
-    entry.blacklist.push_front(arg.token().blacklist(i));
+    UserCentricNetworkTokenEntry entry;
+    entry.app_id = app_id;
+    entry.encryption_key = arg.token().encryption_key();
+    entry.dscp = arg.dscp();
+    for (int i = 0; i < arg.token().blacklist_size(); i++)
+        entry.blacklist.push_front(arg.token().blacklist(i));
 
-  if (!tokenMap_.Insert(entry.app_id, entry)) {
-    return CommandFailure(-1, "failed to modify entry");
-  }
+    if (!tokenMap_.Insert(entry.app_id, entry)) {
+        return CommandFailure(-1, "failed to modify entry");
+    }
 
-  UpdateAuthoritativeDscpMarkings();
-  return CommandSuccess();
+    UpdateAuthoritativeDscpMarkings();
+    return CommandSuccess();
 };
 
 CommandResponse
 NTF::CommandEntryDelete(const ntf::pb::NtfEntryDeleteArg &arg) {
-  LOG(WARNING) << __FUNCTION__;
+    LOG(WARNING) << __FUNCTION__;
 
-  uint32_t app_id;
+    uint32_t app_id;
 
-  if (dpid == 0 || arg.dpid() != dpid) {
-    return CommandFailure(-1, "invalid DPID value");
-  }
+    if (dpid == 0 || arg.dpid() != dpid) {
+        return CommandFailure(-1, "invalid DPID value");
+    }
 
-  app_id = arg.app_id();
+    app_id = arg.app_id();
 
-  if (!tokenMap_.Find(app_id)) {
-    return CommandFailure(-1, "cannot find token with this app_id");
-  }
+    if (!tokenMap_.Find(app_id)) {
+        return CommandFailure(-1, "cannot find token with this app_id");
+    }
 
-  tokenMap_.Remove(app_id);
-  UpdateAuthoritativeDscpMarkings();
-  return CommandSuccess();
+    tokenMap_.Remove(app_id);
+    UpdateAuthoritativeDscpMarkings();
+    return CommandSuccess();
 }
 
 FlowId NTF::GetFlowId(bess::Packet *pkt) {
 
-  Ipv4 *ip = pkt->head_data<Ipv4 *>(sizeof(Ethernet));
-  size_t ip_bytes = (ip->header_length) << 2;
+    Ipv4 *ip = pkt->head_data<Ipv4 *>(sizeof(Ethernet));
+    size_t ip_bytes = (ip->header_length) << 2;
 
-  Udp *udp = pkt->head_data<Udp *>(sizeof(Ethernet) + ip_bytes);
-  FlowId id = {ip->src.value(), ip->dst.value(), ip->protocol,
-               udp->src_port.value(), udp->dst_port.value()};
+    Udp *udp = pkt->head_data<Udp *>(sizeof(Ethernet) + ip_bytes);
+    FlowId id = {ip->src.value(), ip->dst.value(), ip->protocol,
+                             udp->src_port.value(), udp->dst_port.value()};
 
-  return id;
+    return id;
 };
 
 FlowId NTF::GetReverseFlowId(FlowId flow_id) {
-  FlowId reverse_flow_id = flow_id;
-  std::swap(reverse_flow_id.src_addr, reverse_flow_id.dst_addr);
-  std::swap(reverse_flow_id.src_tp,reverse_flow_id.dst_tp);
-  return reverse_flow_id;
+    FlowId reverse_flow_id = flow_id;
+    std::swap(reverse_flow_id.src_addr, reverse_flow_id.dst_addr);
+    std::swap(reverse_flow_id.src_tp,reverse_flow_id.dst_tp);
+    return reverse_flow_id;
 };
 
 /** Extracts a token from a packet.
@@ -188,212 +188,216 @@ FlowId NTF::GetReverseFlowId(FlowId flow_id) {
  */
 std::optional<NetworkToken> NTF::ExtractNetworkTokenFromPacket(bess::Packet *pkt) {
 
-  // The packet should be an Ethernet frame
-  size_t offset = 0;
-  Ethernet *eth = pkt->head_data<Ethernet *>();
-  if (eth->ether_type.value() == Ethernet::Type::kIpv4) {
-    offset += sizeof(Ethernet);
-  } else {
-    return {};
-  }
-
-  // Ensure this is a UDP packet.
-  Ipv4 *ip = pkt->head_data<Ipv4 *>(offset);
-  if (ip->protocol != IpProto::kUdp) {
-    return {};
-  }
-  offset += (ip->header_length << 2);
-
-  // Ensure UDP packet has payload.
-  Udp *udp = pkt->head_data<Udp *>(offset);
-
-  // For this to be a STUN message with an attribute, it needs to be > 28 bytes
-  // 8 bytes for UDP header and 20 bytes for STUN message, and more for attribute.
-  const size_t STUN_PACKET_MIN(sizeof(Udp) + sizeof(Stun));
-  if (udp->length.value() <= STUN_PACKET_MIN) {
-    return {};
-  }
-
-  offset += sizeof(Udp);
-
-  // Try to interpret this as a STUN message. Is it a valid
-  // STUN message length?
-  // TODO(@yiannis): check that message type is also valid.
-  Stun *stun = pkt->head_data<Stun *>(offset);
-  if (stun->message_length.value() != udp->length.value() - STUN_PACKET_MIN) {
-    return {};
-  }
-
-  size_t remaining_bytes = stun->message_length.value();
-
-  uint8_t * next_attribute = reinterpret_cast<uint8_t*> (stun + 1);
-  const size_t stun_msg_length = stun->message_length.value();
-  const uint8_t * end = reinterpret_cast<uint8_t*>(stun) + stun_msg_length;
-
-  while(next_attribute < end) {
-    StunAttribute * attribute = reinterpret_cast<StunAttribute *>(next_attribute);
-    if (attribute->type == be16_t(AttributeTypes::kNetworkToken)) {
-      NetworkToken token;
-      NetworkTokenHeader * token_header = reinterpret_cast<NetworkTokenHeader *>(attribute->payload_);
-
-      token.app_id = token_header->header.value() & 0x0FFFFFFF;
-      token.reflect_type = (token_header->header.value() & 0xF0000000) >> 28;
-      token.payload = std::string(token_header->payload,attribute->length.value());
-      return { token };
+    // The packet should be an Ethernet frame
+    size_t offset = 0;
+    Ethernet *eth = pkt->head_data<Ethernet *>();
+    if (eth->ether_type.value() == Ethernet::Type::kIpv4) {
+        offset += sizeof(Ethernet);
+    } else {
+        return {};
     }
 
-    // STUN attributes are 32-bit aligned, but length reflects number of bytes
-    // prior to padding. Round-up length appropriately to find the next attribute.
-    uint16_t padded_length = ceil(attribute->length.value()/(double)4)*4 + 4;
-    // if attribute length is < 4 or larger than the remaining bytes for this packet,
-    // the packet is not STUN, or it is malformed, or we screwed parsing. Move on.
-    // If remaining bytes == padded_length then we finished parsing this packet.
-    if (padded_length < 4 || padded_length >= remaining_bytes) {
-      return {};
+    // Ensure this is a UDP packet.
+    Ipv4 *ip = pkt->head_data<Ipv4 *>(offset);
+    if (ip->protocol != IpProto::kUdp) {
+        return {};
     }
-    remaining_bytes -= padded_length; // type + length + padded payload
-    next_attribute += padded_length;
-  }
-  return {};
+    offset += (ip->header_length << 2);
+
+    // Ensure UDP packet has payload.
+    Udp *udp = pkt->head_data<Udp *>(offset);
+
+    // For this to be a STUN message with an attribute, it needs to be > 28 bytes
+    // 8 bytes for UDP header and 20 bytes for STUN message, and more for attribute.
+    const size_t STUN_PACKET_MIN(sizeof(Udp) + sizeof(Stun));
+    if (udp->length.value() <= STUN_PACKET_MIN) {
+        return {};
+    }
+
+    offset += sizeof(Udp);
+
+    // Try to interpret this as a STUN message. Is it a valid
+    // STUN message length?
+    // TODO(@yiannis): check that message type is also valid.
+    Stun *stun = pkt->head_data<Stun *>(offset);
+    if (stun->message_length.value() != udp->length.value() - STUN_PACKET_MIN) {
+        return {};
+    }
+
+    size_t remaining_bytes = stun->message_length.value();
+
+    uint8_t * next_attribute = reinterpret_cast<uint8_t*> (stun + 1);
+    const size_t stun_msg_length = stun->message_length.value();
+    const uint8_t * end = reinterpret_cast<uint8_t*>(stun) + stun_msg_length;
+
+    while(next_attribute < end) {
+        StunAttribute * attribute = reinterpret_cast<StunAttribute *>(next_attribute);
+        if (attribute->type == be16_t(AttributeTypes::kNetworkToken)) {
+            NetworkToken token;
+            NetworkTokenHeader * token_header = reinterpret_cast<NetworkTokenHeader *>(attribute->payload_);
+
+            token.app_id = token_header->header.value() & 0x0FFFFFFF;
+            token.reflect_type = (token_header->header.value() & 0xF0000000) >> 28;
+            token.payload = std::string(token_header->payload,attribute->length.value());
+            return { token };
+        }
+
+        // STUN attributes are 32-bit aligned, but length reflects number of
+        // bytes prior to padding. Round-up length appropriately to find the
+        // next attribute.
+        uint16_t padded_length = ceil(attribute->length.value()/(double)4)*4 + 4;
+        // if attribute length is < 4 or larger than the remaining bytes for
+        // this packet, the packet is not STUN, or it is malformed, or we
+        // screwed parsing. Move on.  If remaining bytes == padded_length then
+        // we finished parsing this packet.
+        if (padded_length < 4 || padded_length >= remaining_bytes) {
+            return {};
+        }
+        remaining_bytes -= padded_length; // type + length + padded payload
+        next_attribute += padded_length;
+    }
+    return {};
 };
 
 void NTF::CheckPacketForNetworkToken(Context *ctx, bess::Packet *pkt) {
-  std::optional<NetworkToken> token;
-  FlowId flow_id;
-  FlowId reverse_flow_id;
+    std::optional<NetworkToken> token;
+    FlowId flow_id;
+    FlowId reverse_flow_id;
 
-  token = ExtractNetworkTokenFromPacket(pkt);
-  if(!token) {
-    return;
-  }
+    token = ExtractNetworkTokenFromPacket(pkt);
+    if(!token) {
+        return;
+    }
 
-  DLOG(WARNING) << "Found a token with app-id " << std::hex << token->app_id << std::dec;
+    DLOG(WARNING) << "Found a token with app-id " << std::hex << token->app_id << std::dec;
 
-  auto *hash_item = tokenMap_.Find(token->app_id);
-  if(!hash_item) {
-    return;
-  }
+    auto *hash_item = tokenMap_.Find(token->app_id);
+    if(!hash_item) {
+        return;
+    }
 
-  NtfFlowEntry new_ntf_flow;
-  json_t * _token = nte_decrypt(token->payload.c_str(), hash_item->second.encryption_key.c_str());
-  if (!_token) {
-    DLOG(WARNING) << "NTE Decrypt did not find a valid token";
-    return;
-  }
+    NtfFlowEntry new_ntf_flow;
+    json_t * _token = nte_decrypt(token->payload.c_str(), hash_item->second.encryption_key.c_str());
+    if (!_token) {
+        DLOG(WARNING) << "NTE Decrypt did not find a valid token";
+        return;
+    }
 
-  uint64_t exp_ns = json_integer_value(json_object_get(_token, "exp"))*1e9;
-  std::string bound_ip = json_string_value(json_object_get(_token,"bip"));
-  be32_t bound_address;
-  if (exp_ns < ctx->current_ns) {
-    DLOG(WARNING) << "Detected token is expired --- ignoring...";
-    return;
-  }
-  if (!ParseIpv4Address(bound_ip, &bound_address)) {
-    DLOG(WARNING) << "Detected token does not have a valid bound IP address --- ignoring...";
-    return;
-  }
+    uint64_t exp_ns = json_integer_value(json_object_get(_token, "exp"))*1e9;
+    std::string bound_ip = json_string_value(json_object_get(_token,"bip"));
+    be32_t bound_address;
+    if (exp_ns < ctx->current_ns) {
+        DLOG(WARNING) << "Detected token is expired --- ignoring...";
+        return;
+    }
+    if (!ParseIpv4Address(bound_ip, &bound_address)) {
+        DLOG(WARNING) << "Detected token does not have a valid bound IP address --- ignoring...";
+        return;
+    }
 
-  // We have the expiration time and bound ip for this token. Now we need to check
-  // if the bound ip matches ip source or destination.
-  Ipv4 *ip = pkt->head_data<Ipv4 *>(sizeof(Ethernet));
-  if ((bound_address != ip->src) && (bound_address != ip->dst)) {
-    DLOG(WARNING) << "Detected token is bound to an IP other than source and destination (BIP:" <<
-      ToIpv4Address(bound_address) << " SRCIP:" << ToIpv4Address(ip->src) << " DSTIP:" << ToIpv4Address(ip->dst);
-    return;
-  }
+    // We have the expiration time and bound ip for this token. Now we need to
+    // check if the bound ip matches ip source or destination.
+    Ipv4 *ip = pkt->head_data<Ipv4 *>(sizeof(Ethernet));
+    if ((bound_address != ip->src) && (bound_address != ip->dst)) {
+        DLOG(WARNING) << "Detected token is bound to an IP other than source and destination (BIP:" <<
+            ToIpv4Address(bound_address) << " SRCIP:" << ToIpv4Address(ip->src) << " DSTIP:" << ToIpv4Address(ip->dst);
+        return;
+    }
 
-  // if we made it that far, this is a valid token and we should take action.
-  new_ntf_flow.last_refresh = ctx->current_ns;
-  new_ntf_flow.dscp = hash_item->second.dscp;
-  flow_id = GetFlowId(pkt);
-  reverse_flow_id = GetReverseFlowId(flow_id);
-  flowMap_.Insert(flow_id, new_ntf_flow);
-  flowMap_.Insert(reverse_flow_id, new_ntf_flow);
+    // if we made it that far, this is a valid token and we should take action.
+    new_ntf_flow.last_refresh = ctx->current_ns;
+    new_ntf_flow.dscp = hash_item->second.dscp;
+    flow_id = GetFlowId(pkt);
+    reverse_flow_id = GetReverseFlowId(flow_id);
+    flowMap_.Insert(flow_id, new_ntf_flow);
+    flowMap_.Insert(reverse_flow_id, new_ntf_flow);
 
-  DLOG(WARNING) << "Verified token with app-id " << std::hex << token->app_id << " --- marking packets with DSCP " << (uint16_t) new_ntf_flow.dscp << std::dec;
+    DLOG(WARNING) << "Verified token with app-id " << std::hex << token->app_id
+                  << " --- marking packets with DSCP "
+                  << (uint16_t) new_ntf_flow.dscp << std::dec;
 }
 
 void NTF::ResetDscpMarking(bess::Packet *pkt) {
-  Ipv4 *ip = pkt->head_data<Ipv4 *>(sizeof(Ethernet));
-  // Do nothing if TOS is 0.
-  // This will be the most common, so check first to avoid set lookup.
-  if (ip->type_of_service == 0) {
-    return;
-  }
+    Ipv4 *ip = pkt->head_data<Ipv4 *>(sizeof(Ethernet));
+    // Do nothing if TOS is 0.
+    // This will be the most common, so check first to avoid set lookup.
+    if (ip->type_of_service == 0) {
+        return;
+    }
 
-  // If TOS is one of our authoritative DSCP markings, set it to 0,
-  // otherwise leave as is.
-  if (authoritative_dscp_markings.count(ip->type_of_service) > 0) {
-    ip->type_of_service = 0;
-  }
+    // If TOS is one of our authoritative DSCP markings, set it to 0,
+    // otherwise leave as is.
+    if (authoritative_dscp_markings.count(ip->type_of_service) > 0) {
+        ip->type_of_service = 0;
+    }
 }
 
 void NTF::SetDscpMarking(bess::Packet *pkt, uint8_t dscp) {
-  Ipv4 *ip = pkt->head_data<Ipv4 *>(sizeof(Ethernet));
-  ip->type_of_service = dscp;
+    Ipv4 *ip = pkt->head_data<Ipv4 *>(sizeof(Ethernet));
+    ip->type_of_service = dscp;
 }
 
 void NTF::UpdateAuthoritativeDscpMarkings() {
-  using TokenTable = bess::utils::CuckooMap<uint32_t, UserCentricNetworkTokenEntry>;
-  // go over all entries and add all dscp actions to the authoritative list.
-  for (TokenTable::iterator it=tokenMap_.begin(); it!=tokenMap_.end(); ++it) {
-    authoritative_dscp_markings.insert(it->second.dscp);
-  }
+    using TokenTable = bess::utils::CuckooMap<uint32_t, UserCentricNetworkTokenEntry>;
+    // go over all entries and add all dscp actions to the authoritative list.
+    for (TokenTable::iterator it=tokenMap_.begin(); it!=tokenMap_.end(); ++it) {
+        authoritative_dscp_markings.insert(it->second.dscp);
+    }
 }
 
 void NTF::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
-  int cnt = batch->cnt();
+    int cnt = batch->cnt();
 
-  FlowId flow_id;
-  FlowId reverse_flow_id;
+    FlowId flow_id;
+    FlowId reverse_flow_id;
 
-  uint64_t now = ctx->current_ns;
+    uint64_t now = ctx->current_ns;
 
-  for (int i = 0; i < cnt; i++ ) {
-    bess::Packet *pkt = batch->pkts()[i];
+    for (int i = 0; i < cnt; i++ ) {
+        bess::Packet *pkt = batch->pkts()[i];
 
-    // First check if this packet has a network token
-    // Flows that have a valid network token are inserted
-    // in a FlowTable. We assume a bidirectional (non-reflecting) token
-    // and proactivelyinsert both directions.
-    CheckPacketForNetworkToken(ctx, pkt);
+        // First check if this packet has a network token
+        // Flows that have a valid network token are inserted
+        // in a FlowTable. We assume a bidirectional (non-reflecting) token
+        // and proactively insert both directions.
+        CheckPacketForNetworkToken(ctx, pkt);
 
-    // If this flow is on the whitelist table, we need to set the DSCP
-    // marking. We reset the DSCP marking for all other flows.
-    flow_id = GetFlowId(pkt);
-    reverse_flow_id = GetReverseFlowId(flow_id);
-    auto *hash_item = flowMap_.Find(flow_id);
-    auto *hash_reverse_item = flowMap_.Find(reverse_flow_id);
+        // If this flow is on the whitelist table, we need to set the DSCP
+        // marking. We reset the DSCP marking for all other flows.
+        flow_id = GetFlowId(pkt);
+        reverse_flow_id = GetReverseFlowId(flow_id);
+        auto *hash_item = flowMap_.Find(flow_id);
+        auto *hash_reverse_item = flowMap_.Find(reverse_flow_id);
 
-    (void) hash_item;
-    (void) hash_reverse_item;
+        (void) hash_item;
+        (void) hash_reverse_item;
 
-    if (hash_item == nullptr) {
-      ResetDscpMarking(pkt);
-    } else {
-      // Forward and Reverse entries must have the same lifespan.
-      DCHECK(hash_reverse_item != nullptr);
+        if (hash_item == nullptr) {
+            ResetDscpMarking(pkt);
+        } else {
+            // Forward and Reverse entries must have the same lifespan.
+            DCHECK(hash_reverse_item != nullptr);
 
-      // lazily remove expired flows
-      // TODO(@yiannis): we should check expired flows when adding
-      // new flows as well.
-      if (now - hash_item->second.last_refresh> kTimeOutNs) {
-        flowMap_.Remove(hash_item->first);
-        flowMap_.Remove(hash_reverse_item->first);
-        ResetDscpMarking(pkt);
-      } else {
-        SetDscpMarking(pkt, hash_item->second.dscp);
-        hash_item->second.last_refresh = now;
-        hash_reverse_item->second.last_refresh = now;
-      }
+            // lazily remove expired flows
+            // TODO(@yiannis): we should check expired flows when adding
+            // new flows as well.
+            if (now - hash_item->second.last_refresh> kTimeOutNs) {
+                flowMap_.Remove(hash_item->first);
+                flowMap_.Remove(hash_reverse_item->first);
+                ResetDscpMarking(pkt);
+            } else {
+                SetDscpMarking(pkt, hash_item->second.dscp);
+                hash_item->second.last_refresh = now;
+                hash_reverse_item->second.last_refresh = now;
+            }
+        }
     }
-  }
-  RunNextModule(ctx, batch);
+    RunNextModule(ctx, batch);
 };
 
 std::string NTF::GetDesc() const {
-  return bess::utils::Format("%zu services, %zu active tokens",
-        tokenMap_.Count(), flowMap_.Count());
+    return bess::utils::Format("%zu services, %zu active tokens",
+            tokenMap_.Count(), flowMap_.Count());
 }
 
 ADD_MODULE(NTF, "ntf", "interprets network tokens and enforces appropriate action")

--- a/modules/ntf.cc
+++ b/modules/ntf.cc
@@ -55,7 +55,8 @@ NTF::Init(const bess::pb::EmptyArg &) {
 
 CommandResponse
 NTF::CommandTableCreate(const ntf::pb::NtfTableCreateArg &arg) {
-    LOG(WARNING) << __FUNCTION__ << " " << arg.dpid() << arg.max_entries() ;
+    LOG(WARNING) << __FUNCTION__ << "(dpid=" << arg.dpid() << ", max_entries="
+                 << arg.max_entries() << ")" ;
 
     if (dpid) {
         LOG(WARNING) << "Token table with DPID " << dpid <<
@@ -73,7 +74,7 @@ NTF::CommandTableCreate(const ntf::pb::NtfTableCreateArg &arg) {
 
 CommandResponse
 NTF::CommandTableDelete(const ntf::pb::NtfTableDeleteArg &arg) {
-    LOG(WARNING) << __FUNCTION__ << " " << arg.dpid();
+    LOG(WARNING) << __FUNCTION__ << "(dpid=" << arg.dpid() << ")";
 
     if (dpid != arg.dpid() || dpid == 0) {
         return CommandFailure(-1, "invalid DPID value");
@@ -87,7 +88,10 @@ NTF::CommandTableDelete(const ntf::pb::NtfTableDeleteArg &arg) {
 
 CommandResponse
 NTF::CommandEntryCreate(const ntf::pb::NtfEntryCreateArg &arg) {
-    LOG(WARNING) << __FUNCTION__;
+    LOG(WARNING) << __FUNCTION__ << "(dpid=" << arg.dpid() << ", app_id="
+                 << arg.token().app_id() << ", encryption_key="
+                 << arg.token().encryption_key() << ", dscp=" << arg.dscp()
+                 << ")";
 
     uint32_t app_id;
 
@@ -138,7 +142,10 @@ NTF::CommandEntryCreate(const ntf::pb::NtfEntryCreateArg &arg) {
 
 CommandResponse
 NTF::CommandEntryModify(const ntf::pb::NtfEntryModifyArg &arg) {
-    LOG(WARNING) << __FUNCTION__;
+    LOG(WARNING) << __FUNCTION__ << "(dpid=" << arg.dpid() << ", app_id="
+                 << arg.token().app_id() << ", encryption_key="
+                 << arg.token().encryption_key() << ", dscp=" << arg.dscp()
+                 << ")";
 
     uint32_t app_id;
 
@@ -168,6 +175,9 @@ NTF::CommandEntryModify(const ntf::pb::NtfEntryModifyArg &arg) {
 
 CommandResponse
 NTF::CommandEntryDelete(const ntf::pb::NtfEntryDeleteArg &arg) {
+    LOG(WARNING) << __FUNCTION__ << "(dpid=" << arg.dpid() << ", app_id="
+                 << arg.app_id() << ")";
+
     LOG(WARNING) << __FUNCTION__;
 
     uint32_t app_id;

--- a/modules/ntf.cc
+++ b/modules/ntf.cc
@@ -305,18 +305,18 @@ void NTF::CheckPacketForNetworkToken(Context *ctx, bess::Packet *pkt) {
         return;
     }
 
-    LOG(WARNING) << "Found a token with app-id 0x" << std::hex << token->app_id << std::dec;
+    DLOG(WARNING) << "Found a token with app-id 0x" << std::hex << token->app_id << std::dec;
 
     auto *hash_item = tokenMap_.Find(token->app_id);
     if(!hash_item) {
-        LOG(WARNING) << "No app with ID: 0x" << std::hex << token->app_id << std::dec;
+        DLOG(WARNING) << "No app with ID: 0x" << std::hex << token->app_id << std::dec;
         return;
     }
 
     NtfFlowEntry new_ntf_flow;
     json_t * _token = nte_decrypt(token->payload.c_str(), hash_item->second.encryption_key.c_str());
     if (!_token) {
-        LOG(WARNING) << "NTE Decrypt did not find a valid token";
+        DLOG(WARNING) << "NTE Decrypt did not find a valid token";
         return;
     }
 
@@ -324,11 +324,11 @@ void NTF::CheckPacketForNetworkToken(Context *ctx, bess::Packet *pkt) {
     std::string bound_ip = json_string_value(json_object_get(_token,"bip"));
     be32_t bound_address;
     if (exp_ns < ctx->current_ns) {
-        LOG(WARNING) << "Detected token is expired --- ignoring...";
+        DLOG(WARNING) << "Detected token is expired --- ignoring...";
         return;
     }
     if (!ParseIpv4Address(bound_ip, &bound_address)) {
-        LOG(WARNING) << "Detected token does not have a valid bound IP address --- ignoring...";
+        DLOG(WARNING) << "Detected token does not have a valid bound IP address --- ignoring...";
         return;
     }
 
@@ -336,7 +336,7 @@ void NTF::CheckPacketForNetworkToken(Context *ctx, bess::Packet *pkt) {
     // check if the bound ip matches ip source or destination.
     Ipv4 *ip = pkt->head_data<Ipv4 *>(sizeof(Ethernet));
     if ((bound_address != ip->src) && (bound_address != ip->dst)) {
-        LOG(WARNING) << "Detected token is bound to an IP other than source and destination (BIP:" <<
+        DLOG(WARNING) << "Detected token is bound to an IP other than source and destination (BIP:" <<
             ToIpv4Address(bound_address) << " SRCIP:" << ToIpv4Address(ip->src) << " DSTIP:" << ToIpv4Address(ip->dst);
         return;
     }
@@ -350,9 +350,9 @@ void NTF::CheckPacketForNetworkToken(Context *ctx, bess::Packet *pkt) {
     flowMap_.Insert(flow_id, new_ntf_flow);
     flowMap_.Insert(reverse_flow_id, new_ntf_flow);
 
-    LOG(WARNING) << "Verified token with app-id 0x" << std::hex << token->app_id
-                 << " --- marking packets with DSCP 0x"
-                 << (uint16_t) new_ntf_flow.dscp << std::dec;
+    DLOG(WARNING) << "Verified token with app-id 0x" << std::hex << token->app_id
+                  << " --- marking packets with DSCP 0x"
+                  << (uint16_t) new_ntf_flow.dscp << std::dec;
 }
 
 void NTF::ResetDscpMarking(bess::Packet *pkt) {

--- a/modules/ntf.h
+++ b/modules/ntf.h
@@ -74,13 +74,14 @@ using bess::utils::be32_t;
 
 struct NtfFlowActionFlags {
     unsigned set_dscp :1;
-    unsigned set_app_id :1;
+    unsigned set_rule_id :1;
 };
 
 struct NtfFlowEntry {
     uint64_t last_refresh; // in nanoseconds
     uint32_t app_id;
     uint8_t dscp;
+    uint32_t rule_id;
     struct NtfFlowActionFlags flags;
 };
 
@@ -233,8 +234,8 @@ class NTF final : public Module {
     // State for tokens.
     TokenTable tokenMap_;
 
-    // Field for app_id attribute
-    int app_id_attr = -1;
+    // Field for rule ID attribute
+    int rule_id_attr = -1;
 };
 
 #endif // BESS_MODULES_NTF_H_

--- a/modules/ntf.h
+++ b/modules/ntf.h
@@ -45,174 +45,174 @@ using bess::utils::be32_t;
 
 /**
  * NTF detects network tokens in STUN messages,
- * and sets the appropriate DSCP marking. 
- * 
+ * and sets the appropriate DSCP marking.
+ *
  * Method of operation:
- * 
+ *
  * NTF holds a number of network token entries in tokenTable. Each entry
  * describes a token, and is indexed through a unique app_id. app_id means a
  * network token application. For the purposes of this implementation an app_id
  * identifies a service offered by an operator. A network token entry includes
  * the key with which tokens are encrypted/decrypted, a blacklist, and the
- * actions to take when a token is detected. 
- * 
+ * actions to take when a token is detected.
+ *
  * The only supported action right now is to mark the packet with a specific
- * DSCP codepoint.  To prevent abuse, NTF assumes authoritative actions with
+ * DSCP codepoint.    To prevent abuse, NTF assumes authoritative actions with
  * regards to DSCP markings. If deemed responsible for a specific codepoint,
  * only packets/flows with valid tokens will have this marking. If such marking
- * is found in other flows, it will be reset to 0. 
- * 
+ * is found in other flows, it will be reset to 0.
+ *
  * Every packet that enters NTF is checked for network tokens (currently only
- * as STUN attributes).  When a valid token is detected, NTF enforces the
- * respective action and sets the DSCP marking.  NTF also (temporarily) stores
+ * as STUN attributes).    When a valid token is detected, NTF enforces the
+ * respective action and sets the DSCP marking.    NTF also (temporarily) stores
  * the 5-tuple of this flow into flow table, so that subsequent packets of this
  * flow are associated with this token.
- * 
+ *
  * Packets with no tokens (or with invalid/unverified tokens) pass through the
- * NTF with no changes (apart from DSCP reseting as discussed earlier). 
+ * NTF with no changes (apart from DSCP reseting as discussed earlier).
  */
 
 struct NtfFlowEntry {
-  uint64_t last_refresh; // in nanoseconds
-  uint8_t dscp;
+    uint64_t last_refresh; // in nanoseconds
+    uint8_t dscp;
 };
 
 struct NetworkTokenHeader {
-  be32_t header;
-  char payload[];
+    be32_t header;
+    char payload[];
 };
 
 struct NetworkToken {
-  uint8_t reflect_type;
-  uint32_t app_id;
-  std::string payload;
+    uint8_t reflect_type;
+    uint32_t app_id;
+    std::string payload;
 };
 
 struct FlowId {
-  uint32_t src_addr;
-  uint32_t dst_addr;
+    uint32_t src_addr;
+    uint32_t dst_addr;
 
-  uint8_t protocol;
+    uint8_t protocol;
 
-  uint16_t src_tp;
-  uint16_t dst_tp;
+    uint16_t src_tp;
+    uint16_t dst_tp;
 };
 
 struct Flow {
-  FlowId id;
+    FlowId id;
 
-  // hashes a FlowId
-  struct Hash {
-    // a similar method to boost's hash_combine in order to combine hashes
-    inline void combine(std::size_t &hash, const unsigned int &val) const {
-      std::hash<unsigned int> hasher;
-      hash ^= hasher(val) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
-    }
-    bess::utils::HashResult operator()(const FlowId &id) const {
-      std::size_t hash = 0;
-      combine(hash, id.src_addr);
-      combine(hash, id.dst_addr);
-      combine(hash, id.src_tp);
-      combine(hash, id.dst_tp);
-      combine(hash, (uint32_t)id.protocol);
-      return hash;
-    }
-  };
+    // hashes a FlowId
+    struct Hash {
+        // a similar method to boost's hash_combine in order to combine hashes
+        inline void combine(std::size_t &hash, const unsigned int &val) const {
+            std::hash<unsigned int> hasher;
+            hash ^= hasher(val) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
+        }
+        bess::utils::HashResult operator()(const FlowId &id) const {
+            std::size_t hash = 0;
+            combine(hash, id.src_addr);
+            combine(hash, id.dst_addr);
+            combine(hash, id.src_tp);
+            combine(hash, id.dst_tp);
+            combine(hash, (uint32_t)id.protocol);
+            return hash;
+        }
+    };
 
-  // to compare two FlowId for equality in a hash table
-  struct EqualTo {
-    bool operator()(const FlowId &id1, const FlowId &id2) const {
-      bool ips =
-          (id1.src_addr == id2.src_addr) && (id1.dst_addr == id2.dst_addr);
-      bool ports =
-          (id1.src_tp == id2.src_tp) && (id1.dst_tp == id2.dst_tp);
-      return (ips && ports) && (id1.protocol == id2.protocol);
-    }
-  };
+    // to compare two FlowId for equality in a hash table
+    struct EqualTo {
+        bool operator()(const FlowId &id1, const FlowId &id2) const {
+            bool ips =
+                    (id1.src_addr == id2.src_addr) && (id1.dst_addr == id2.dst_addr);
+            bool ports =
+                    (id1.src_tp == id2.src_tp) && (id1.dst_tp == id2.dst_tp);
+            return (ips && ports) && (id1.protocol == id2.protocol);
+        }
+    };
 };
 
 struct UserCentricNetworkTokenEntry {
-  uint32_t app_id;
-  std::string encryption_key;
-  std::list<uint64_t> blacklist;
-  uint32_t id;
-  uint8_t dscp;
+    uint32_t app_id;
+    std::string encryption_key;
+    std::list<uint64_t> blacklist;
+    uint32_t id;
+    uint8_t dscp;
 };
 
 class NTF final : public Module {
  public:
-  static const Commands cmds;
+    static const Commands cmds;
 
-  uint32_t dpid;
-  uint16_t max_token_entries;
-  
-  CommandResponse Init(const bess::pb::EmptyArg &arg);
+    uint32_t dpid;
+    uint16_t max_token_entries;
 
-  CommandResponse CommandTableCreate(const ntf::pb::NtfTableCreateArg &arg);
-  CommandResponse CommandTableDelete(const ntf::pb::NtfTableDeleteArg &arg);
-  CommandResponse CommandEntryCreate(const ntf::pb::NtfEntryCreateArg &arg);
-  CommandResponse CommandEntryModify(const ntf::pb::NtfEntryModifyArg &arg);
-  CommandResponse CommandEntryDelete(const ntf::pb::NtfEntryDeleteArg &arg);
+    CommandResponse Init(const bess::pb::EmptyArg &arg);
 
-  void ProcessBatch(Context*, bess::PacketBatch*) override;
+    CommandResponse CommandTableCreate(const ntf::pb::NtfTableCreateArg &arg);
+    CommandResponse CommandTableDelete(const ntf::pb::NtfTableDeleteArg &arg);
+    CommandResponse CommandEntryCreate(const ntf::pb::NtfEntryCreateArg &arg);
+    CommandResponse CommandEntryModify(const ntf::pb::NtfEntryModifyArg &arg);
+    CommandResponse CommandEntryDelete(const ntf::pb::NtfEntryDeleteArg &arg);
 
-  std::string GetDesc() const override;
+    void ProcessBatch(Context*, bess::PacketBatch*) override;
+
+    std::string GetDesc() const override;
 
  private:
-  using FlowTable = bess::utils::CuckooMap<
-    FlowId, NtfFlowEntry, Flow::Hash, Flow::EqualTo>;
-  using TokenTable = bess::utils::CuckooMap<
-    uint32_t, UserCentricNetworkTokenEntry>;
+    using FlowTable = bess::utils::CuckooMap<
+        FlowId, NtfFlowEntry, Flow::Hash, Flow::EqualTo>;
+    using TokenTable = bess::utils::CuckooMap<
+        uint32_t, UserCentricNetworkTokenEntry>;
 
-  // 5 minutes for entry expiration
-  static const uint64_t kTimeOutNs = 300ull * 1000 * 1000 * 1000;
-  std::set<uint8_t> authoritative_dscp_markings;
+    // 5 minutes for entry expiration
+    static const uint64_t kTimeOutNs = 300ull * 1000 * 1000 * 1000;
+    std::set<uint8_t> authoritative_dscp_markings;
 
-  FlowTable::Entry *CreateNewEntry(const Flow &flow, uint64_t now);
+    FlowTable::Entry *CreateNewEntry(const Flow &flow, uint64_t now);
 
-  /**
-   * Checks whether a packet contains a network token. 
-   * Currently looks at tokens encoded as STUN attributes. This function
-   * just detects tokens, but doesn't attempt to verify and/or evaluate them.
-   * 
-   * Returns pointer to the network token, or nullptr if no token found.
-   */ 
-  std::optional<NetworkToken> ExtractNetworkTokenFromPacket(bess::Packet *pkt);
+    /**
+     * Checks whether a packet contains a network token.
+     * Currently looks at tokens encoded as STUN attributes. This function
+     * just detects tokens, but doesn't attempt to verify and/or evaluate them.
+     *
+     * Returns pointer to the network token, or nullptr if no token found.
+     */
+    std::optional<NetworkToken> ExtractNetworkTokenFromPacket(bess::Packet *pkt);
 
-  // Get  a flow id (5-tuple) from a packet. 
-  FlowId GetFlowId(bess::Packet *pkt);
+    // Get    a flow id (5-tuple) from a packet.
+    FlowId GetFlowId(bess::Packet *pkt);
 
-  // Get a reverse flow id by swapping ip address and transport ports.
-  FlowId GetReverseFlowId(FlowId flow_id);
+    // Get a reverse flow id by swapping ip address and transport ports.
+    FlowId GetReverseFlowId(FlowId flow_id);
 
-  /**
-   * CheckPacketForNetworkToken performs all token-related functions for a
-   * packet.  It uses ExtractNetworkTokenFromPacket to detect token for a
-   * packet.  Verifies that this is a valid token and if so, evaluates it.  It
-   * installs the necessary state to apply desired actions (e.g., DSCP marking)
-   * for follow-up packets that belong to the same flow.
-   */
-  void CheckPacketForNetworkToken(Context *ctx, bess::Packet *pkt);
+    /**
+     * CheckPacketForNetworkToken performs all token-related functions for a
+     * packet.    It uses ExtractNetworkTokenFromPacket to detect token for a
+     * packet.    Verifies that this is a valid token and if so, evaluates it.    It
+     * installs the necessary state to apply desired actions (e.g., DSCP marking)
+     * for follow-up packets that belong to the same flow.
+     */
+    void CheckPacketForNetworkToken(Context *ctx, bess::Packet *pkt);
 
-  /**
-   * Resets the token-specific DSCP marking for flows that have not been
-   * whitelisted through a token.
-   */ 
-  void ResetDscpMarking(bess::Packet *pkt);
-  /**
-   * Sets the token-specific DSCP marking for flows that have been whitelisted
-   * through a token.
-   */
-  void SetDscpMarking(bess::Packet *pkt, uint8_t dscp);
+    /**
+     * Resets the token-specific DSCP marking for flows that have not been
+     * whitelisted through a token.
+     */
+    void ResetDscpMarking(bess::Packet *pkt);
+    /**
+     * Sets the token-specific DSCP marking for flows that have been whitelisted
+     * through a token.
+     */
+    void SetDscpMarking(bess::Packet *pkt, uint8_t dscp);
 
-  void UpdateAuthoritativeDscpMarkings();
+    void UpdateAuthoritativeDscpMarkings();
 
-  // Per-flow soft state for flows already whitelisted by a token.
-  FlowTable flowMap_;
+    // Per-flow soft state for flows already whitelisted by a token.
+    FlowTable flowMap_;
 
-  // State for tokens.
-  TokenTable tokenMap_;
-  uint8_t kDSCP = 0;
+    // State for tokens.
+    TokenTable tokenMap_;
+    uint8_t kDSCP = 0;
 };
 
 #endif // BESS_MODULES_NTF_H_

--- a/modules/ntf.h
+++ b/modules/ntf.h
@@ -140,9 +140,9 @@ struct Flow {
     struct EqualTo {
         bool operator()(const FlowId &id1, const FlowId &id2) const {
             bool ips =
-                    (id1.src_addr == id2.src_addr) && (id1.dst_addr == id2.dst_addr);
+               (id1.src_addr == id2.src_addr) && (id1.dst_addr == id2.dst_addr);
             bool ports =
-                    (id1.src_tp == id2.src_tp) && (id1.dst_tp == id2.dst_tp);
+               (id1.src_tp == id2.src_tp) && (id1.dst_tp == id2.dst_tp);
             return (ips && ports) && (id1.protocol == id2.protocol);
         }
     };
@@ -199,7 +199,8 @@ class NTF final : public Module {
      *
      * Returns pointer to the network token, or nullptr if no token found.
      */
-    std::optional<NetworkToken> ExtractNetworkTokenFromPacket(bess::Packet *pkt);
+    std::optional<NetworkToken>
+        ExtractNetworkTokenFromPacket(bess::Packet *pkt);
 
     // Get    a flow id (5-tuple) from a packet.
     FlowId GetFlowId(bess::Packet *pkt);
@@ -209,24 +210,19 @@ class NTF final : public Module {
 
     /**
      * CheckPacketForNetworkToken performs all token-related functions for a
-     * packet.    It uses ExtractNetworkTokenFromPacket to detect token for a
-     * packet.    Verifies that this is a valid token and if so, evaluates it.    It
-     * installs the necessary state to apply desired actions (e.g., DSCP marking)
-     * for follow-up packets that belong to the same flow.
+     * packet.  It uses ExtractNetworkTokenFromPacket to detect token for a
+     * packet.  Verifies that this is a valid token and if so, evaluates it.
+     * It installs the necessary state to apply desired actions (e.g., DSCP
+     * marking) for follow-up packets that belong to the same flow.
      */
     void CheckPacketForNetworkToken(Context *ctx, bess::Packet *pkt);
 
     /**
-     * Marks a given packet according to the parameters specified within the
-     * given NtfFlowEntry.
+     * Assuming *pkt points to a packet from a flow that has presented a valid
+     * network token, apply the actions within the given NtfFlowEntry.
      */
-    void MarkPacket(bess::Packet *pkt, const NtfFlowEntry &NtfFlowEntry);
-
-    /**
-     * Unmarks a given packet, removing any NTF metadata and resetting any
-     * authoritative DSCP markings.
-     */
-    void UnmarkPacket(bess::Packet *pkt);
+    void ApplyFlowActionsToPacket(bess::Packet *pkt,
+                                  const NtfFlowEntry &NtfFlowEntry);
 
     /**
      * Resets the token-specific DSCP marking for flows that have not been

--- a/modules/ntf.h
+++ b/modules/ntf.h
@@ -89,8 +89,8 @@ struct NtfFlowActionFlags {
 struct NtfFlowEntry {
     uint64_t last_refresh; // in nanoseconds
     uint32_t app_id;
-    uint8_t dscp;
     uint32_t rule_id;
+    uint8_t dscp;
     struct NtfFlowActionFlags flags;
 };
 
@@ -108,11 +108,10 @@ struct NetworkToken {
 struct FlowId {
     uint32_t src_addr;
     uint32_t dst_addr;
-
-    uint8_t protocol;
-
     uint16_t src_tp;
     uint16_t dst_tp;
+    uint8_t protocol;
+
 };
 
 struct Flow {

--- a/modules/pcap_source.cc
+++ b/modules/pcap_source.cc
@@ -20,204 +20,207 @@ using namespace bess::utils;
 using ntf::pb::PcapSourceArg;
 
 const Commands PcapSource::cmds = {
-  { "load", "PcapSourceArg",
-     MODULE_CMD_FUNC(&PcapSource::CommandLoad), Command::THREAD_UNSAFE },
+    { "load", "PcapSourceArg", MODULE_CMD_FUNC(&PcapSource::CommandLoad), Command::THREAD_UNSAFE },
 };
 
 CommandResponse
 PcapSource::Init(const PcapSourceArg &args) {
-  return CommandLoad(args);
+    return CommandLoad(args);
 }
 
 CommandResponse
 PcapSource::CommandLoad(const PcapSourceArg &args) {
-  if (pcap) {
-    pcap_close(pcap);
-    pcap = nullptr;
-  }
-
-  // First try parsing as IPv4
-  for(const auto& src_ip : args.src_ip()) {
-    be32_t addr;
-    if (ParseIpv4Address(src_ip, &addr)) {
-      const char *data = reinterpret_cast<const char *>(&addr);
-      src_addr = std::string(data, sizeof(addr));
-    } else {
-      // ... then IPv6
-      struct in6_addr addr6;
-      if (inet_pton(AF_INET6, src_ip.c_str(), &addr6) == 1) {
-        const char *data = reinterpret_cast<const char*>(addr6.s6_addr);
-        src_addr6 = std::string(data, sizeof(addr6.s6_addr));
-      } else {
-        return CommandFailure(errno, "Invalid IP address: %s", src_ip.c_str());
-      }
+    if (pcap) {
+        pcap_close(pcap);
+        pcap = nullptr;
     }
-  }
 
-  reverse = args.reverse();
+    // First try parsing as IPv4
+    for(const auto& src_ip : args.src_ip()) {
+        be32_t addr;
+        if (ParseIpv4Address(src_ip, &addr)) {
+            const char *data = reinterpret_cast<const char *>(&addr);
+            src_addr = std::string(data, sizeof(addr));
+        } else {
+            // ... then IPv6
+            struct in6_addr addr6;
+            if (inet_pton(AF_INET6, src_ip.c_str(), &addr6) == 1) {
+                const char *data = reinterpret_cast<const char*>(addr6.s6_addr);
+                src_addr6 = std::string(data, sizeof(addr6.s6_addr));
+            } else {
+                return CommandFailure(errno, "Invalid IP address: %s", src_ip.c_str());
+            }
+        }
+    }
 
-  char errbuf[PCAP_ERRBUF_SIZE];
-  pcap = pcap_open_offline(args.filename().c_str(), errbuf);
-  if (!pcap) {
-    return CommandFailure(errno, "Failed to open pcap: %s", errbuf);
-  }
+    reverse = args.reverse();
 
-  link_type = pcap_datalink(pcap);
-  switch (link_type) {
-  case DLT_EN10MB:
-  case DLT_RAW:
-    break;
-  default:
-    pcap_close(pcap);
-    pcap = nullptr;
-    return CommandFailure(EINVAL, "Invalid link type: %s",
-        pcap_datalink_val_to_name(link_type));
-  }
+    char errbuf[PCAP_ERRBUF_SIZE];
+    pcap = pcap_open_offline(args.filename().c_str(), errbuf);
+    if (!pcap) {
+        return CommandFailure(errno, "Failed to open pcap: %s", errbuf);
+    }
 
-  task_id_t tid = RegisterTask(nullptr);
-  if (tid == INVALID_TASK_ID) {
-    pcap_close(pcap);
-    pcap = nullptr;
-    return CommandFailure(ENOMEM, "Task creation failed");
-  }
+    link_type = pcap_datalink(pcap);
+    switch (link_type) {
+    case DLT_EN10MB:
+    case DLT_RAW:
+        break;
+    default:
+        pcap_close(pcap);
+        pcap = nullptr;
+        return CommandFailure(EINVAL, "Invalid link type: %s",
+                pcap_datalink_val_to_name(link_type));
+    }
 
-  start_ns = 0;
-  first_packet_ns = 0;
+    task_id_t tid = RegisterTask(nullptr);
+    if (tid == INVALID_TASK_ID) {
+        pcap_close(pcap);
+        pcap = nullptr;
+        return CommandFailure(ENOMEM, "Task creation failed");
+    }
 
-  LOG(INFO) << "PcapSource::Load(): Loaded " << args.filename() << ", "
-               "link_type: " << pcap_datalink_val_to_name(link_type);
-  return CommandSuccess();
+    start_ns = 0;
+    first_packet_ns = 0;
+
+    LOG(INFO) << "PcapSource::Load(): Loaded " << args.filename() << ", "
+                             "link_type: " << pcap_datalink_val_to_name(link_type);
+    return CommandSuccess();
 }
 
 void PcapSource::ProcessBatch(Context *ctx, bess::PacketBatch *batch) {
-  const int cnt = batch->cnt();
-  DLOG(WARNING) << "ProcessBatch() Received batch with " << cnt << " packets";
-  RunNextModule(ctx, batch);
+    const int cnt = batch->cnt();
+    DLOG(WARNING) << "ProcessBatch() Received batch with " << cnt << " packets";
+    RunNextModule(ctx, batch);
 };
 
 
 const u_char *
 PcapSource::LoadNextPacket() {
-  // Try reading the next packet from the PCAP file
-  while (pcap != nullptr) {
-    const u_char* packet = pcap_next(pcap, &next_packet_hdr);
-    if (!packet) {
-      // No way to tell if this is the end of the file or if an error occurred.
-      // Assume we're at the end of the file.
-      pcap_close(pcap);
-      pcap = nullptr;
-      break;
-    }
+    // Try reading the next packet from the PCAP file
+    while (pcap != nullptr) {
+        const u_char* packet = pcap_next(pcap, &next_packet_hdr);
+        if (!packet) {
+            // No way to tell if this is the end of the file or if an error
+            // occurred.  Assume we're at the end of the file.
+            pcap_close(pcap);
+            pcap = nullptr;
+            break;
+        }
 
-    if (!first_packet_ns) {
-      first_packet_ns = next_packet_hdr.ts.tv_sec * 1e9 +
-        next_packet_hdr.ts.tv_usec * 1000;
-    }
+        if (!first_packet_ns) {
+            first_packet_ns = next_packet_hdr.ts.tv_sec * 1e9 +
+                next_packet_hdr.ts.tv_usec * 1000;
+        }
 
-    size_t ip_offset = 0;
-    switch (link_type) {
-    case DLT_RAW:
-      break;
-    case DLT_EN10MB:
-      ip_offset = sizeof(Ethernet);
-      break;
-    }
+        size_t ip_offset = 0;
+        switch (link_type) {
+        case DLT_RAW:
+            break;
+        case DLT_EN10MB:
+            ip_offset = sizeof(Ethernet);
+            break;
+        }
 
-    bool matches = false;
-    const u_char* ip_start = packet + ip_offset;
+        bool matches = false;
+        const u_char* ip_start = packet + ip_offset;
 
-    const Ipv4 *ip = reinterpret_cast<const Ipv4 *>(ip_start);
-    if (ip->version == 4 && src_addr.size() == 4) {
-      const u_char* addr = ip_start + (reverse ? 16 : 12);
-      matches = (0 == memcmp(addr, src_addr.data(), src_addr.size()));
-    } else if (ip->version == 6 && src_addr6.size() == 16) {
-      const u_char* addr = ip_start + (reverse ? 24 : 8);
-      matches = (0 == memcmp(addr, src_addr6.data(), src_addr6.size()));
-    }
+        const Ipv4 *ip = reinterpret_cast<const Ipv4 *>(ip_start);
+        if (ip->version == 4 && src_addr.size() == 4) {
+            const u_char* addr = ip_start + (reverse ? 16 : 12);
+            matches = (0 == memcmp(addr, src_addr.data(), src_addr.size()));
+        } else if (ip->version == 6 && src_addr6.size() == 16) {
+            const u_char* addr = ip_start + (reverse ? 24 : 8);
+            matches = (0 == memcmp(addr, src_addr6.data(), src_addr6.size()));
+        }
 
-    if (matches) {
-      return packet;
+        if (matches) {
+            return packet;
+        }
     }
-  }
-  return nullptr;
+    return nullptr;
 }
 
 bess::Packet *
 PcapSource::PrepareNextPacket() {
-  // Allocate an empty packet from the packet pool
-  bess::Packet *pkt = current_worker.packet_pool()->Alloc();
-  if(!pkt) {
-    DLOG(WARNING) << "Failed to allocate new packet from pool";
-    return nullptr;
-  }
+    // Allocate an empty packet from the packet pool
+    bess::Packet *pkt = current_worker.packet_pool()->Alloc();
+    if(!pkt) {
+        DLOG(WARNING) << "Failed to allocate new packet from pool";
+        return nullptr;
+    }
 
-  char *ptr = pkt->buffer<char *>() + SNBUF_HEADROOM;
-  int size = next_packet_hdr.caplen;
-  int copy_len = std::min(size, static_cast<int>(pkt->tailroom()));
+    char *ptr = pkt->buffer<char *>() + SNBUF_HEADROOM;
+    int size = next_packet_hdr.caplen;
+    int copy_len = std::min(size, static_cast<int>(pkt->tailroom()));
 
-  pkt->set_data_off(SNBUF_HEADROOM);
-  pkt->set_total_len(copy_len);
-  pkt->set_data_len(copy_len);
-  bess::utils::CopyInlined(ptr, next_packet, copy_len, true);
+    pkt->set_data_off(SNBUF_HEADROOM);
+    pkt->set_total_len(copy_len);
+    pkt->set_data_len(copy_len);
+    bess::utils::CopyInlined(ptr, next_packet, copy_len, true);
 
-  size -= copy_len;
-  if (size > 0) {
-    DLOG(WARNING) << "TODO: sending packets too fast...";
-  }
-  return pkt;
+    size -= copy_len;
+    if (size > 0) {
+        DLOG(WARNING) << "TODO: sending packets too fast...";
+    }
+    return pkt;
 }
 
-struct task_result PcapSource::RunTask(Context *ctx, bess::PacketBatch *batch,
-                                       void *) {
-  size_t total_bytes = 0;
-  batch->clear();
+struct task_result PcapSource::RunTask(
+        Context *ctx,
+        bess::PacketBatch *batch,
+        void *)
+{
+    size_t total_bytes = 0;
+    batch->clear();
 
-  if (unlikely(start_ns == 0)) {
-    start_ns = ctx->current_ns;
-  }
-
-  while(pcap != nullptr) {
-    // Load the next packet if it's not already loaded.  It might already be
-    // loaded if we did it last cycle but it was not time to send yet.
-    if (!next_packet) {
-      next_packet = LoadNextPacket();
+    if (unlikely(start_ns == 0)) {
+        start_ns = ctx->current_ns;
     }
 
-    // If next_packet is null at this point, we have reached the end of the
-    // trace.
-    if (!next_packet) {
-      return { .block = true, .packets = 0, .bits = 0 };
+    while(pcap != nullptr) {
+        // Load the next packet if it's not already loaded.  It might already
+        // be loaded if we did it last cycle but it was not time to send yet.
+        if (!next_packet) {
+            next_packet = LoadNextPacket();
+        }
+
+        // If next_packet is null at this point, we have reached the end of the
+        // trace.
+        if (!next_packet) {
+            return { .block = true, .packets = 0, .bits = 0 };
+        }
+
+        const uint64_t now = ctx->current_ns;
+        const uint64_t next_ts = (next_packet_hdr.ts.tv_sec * 1e9 + 
+            next_packet_hdr.ts.tv_usec * 1000) - first_packet_ns + start_ns;
+
+        if (next_ts > now) {
+            // We have caught up to where we should be.
+            break;
+        }
+
+        bess::Packet* pkt = PrepareNextPacket();
+        if(!pkt) {
+            // Packet allocation failed - this shouldn't happen, so stop
+            // sending.
+            return { .block = true, .packets = 0, .bits = 0 };
+        }
+
+        batch->add(pkt);
+        total_bytes += next_packet_hdr.caplen;
+        next_packet = nullptr;
     }
 
-    const uint64_t now = ctx->current_ns;
-    const uint64_t next_ts = (next_packet_hdr.ts.tv_sec * 1e9 + 
-      next_packet_hdr.ts.tv_usec * 1000) - first_packet_ns + start_ns;
+    // Pass any allocated packets to the next module.  It is possible that
+    // batch may contain no packets.
+    RunNextModule(ctx, batch);
 
-    if (next_ts > now) {
-      // We have caught up to where we should be.
-      break;
-    }
-
-    bess::Packet* pkt = PrepareNextPacket();
-    if(!pkt) {
-      // Packet allocation failed - this shouldn't happen, so stop sending.
-      return { .block = true, .packets = 0, .bits = 0 };
-    }
-
-    batch->add(pkt);
-    total_bytes += next_packet_hdr.caplen;
-    next_packet = nullptr;
-  }
-
-  // Pass any allocated packets to the next module.  It is possible that batch
-  // may contain no packets.
-  RunNextModule(ctx, batch);
-
-  return {
-      .block = (pcap == nullptr),
-      .packets = (unsigned) batch->cnt(),
-      .bits = total_bytes * 8,
-  };
+    return {
+        .block = (pcap == nullptr),
+        .packets = (unsigned) batch->cnt(),
+        .bits = total_bytes * 8,
+    };
 };
 
 ADD_MODULE(PcapSource, "pcap_source", "A source that can replay a PCAP file")

--- a/modules/pcap_source.h
+++ b/modules/pcap_source.h
@@ -17,49 +17,49 @@
 using bess::utils::be32_t;
 
 class PcapSource final : public Module {
- public:
-  static const Commands cmds;
-  CommandResponse Init(const ntf::pb::PcapSourceArg &arg);
-  CommandResponse CommandLoad(const ntf::pb::PcapSourceArg &arg);
-  void ProcessBatch(Context*, bess::PacketBatch*) override;
-  struct task_result RunTask(Context*, bess::PacketBatch*, void*);
+public:
+    static const Commands cmds;
+    CommandResponse Init(const ntf::pb::PcapSourceArg &arg);
+    CommandResponse CommandLoad(const ntf::pb::PcapSourceArg &arg);
+    void ProcessBatch(Context*, bess::PacketBatch*) override;
+    struct task_result RunTask(Context*, bess::PacketBatch*, void*);
 
- private:
-  // Loads the next packet from the pcap file.  Populates next_packet_hdr.
-  // Returns nullptr the end of the pcap has been reached.
-  const u_char* LoadNextPacket();
+private:
+    // Loads the next packet from the pcap file.  Populates next_packet_hdr.
+    // Returns nullptr the end of the pcap has been reached.
+    const u_char* LoadNextPacket();
 
-  // Create a bess::Packet with the contents of the next outgoing packet
-  bess::Packet* PrepareNextPacket();
+    // Create a bess::Packet with the contents of the next outgoing packet
+    bess::Packet* PrepareNextPacket();
 
-  // Handle to pcap file
-  pcap_t* pcap = nullptr;
+    // Handle to pcap file
+    pcap_t* pcap = nullptr;
 
-  // Link type of pcap
-  int link_type = DLT_RAW;
+    // Link type of pcap
+    int link_type = DLT_RAW;
 
-  // If false, we will send packets FROM src_ip.  If true, we will send packets
-  // TO src_ip.
-  bool reverse = false;
+    // If false, we will send packets FROM src_ip.  If true, we will send
+    // packets TO src_ip.
+    bool reverse = false;
 
-  // Address of the "client" in the pcap, used for determining which direciton
-  // to send packets.
-  std::string src_addr;
+    // Address of the "client" in the pcap, used for determining which
+    // direciton to send packets.
+    std::string src_addr;
 
-  // Same as src_addr but for IPv6
-  std::string src_addr6;
+    // Same as src_addr but for IPv6
+    std::string src_addr6;
 
-  // Pointer to raw data of next packet (from pcap file)
-  const u_char* next_packet;
+    // Pointer to raw data of next packet (from pcap file)
+    const u_char* next_packet;
 
-  // Information (such as timestamp) of the next packet
-  pcap_pkthdr next_packet_hdr;
+    // Information (such as timestamp) of the next packet
+    pcap_pkthdr next_packet_hdr;
 
-  // Time (relative to boot) when the pcap replay started in nanoseconds
-  uint64_t start_ns;
+    // Time (relative to boot) when the pcap replay started in nanoseconds
+    uint64_t start_ns;
 
-  // Timestamp (POSIX) of the first packet in nanoseconds
-  uint64_t first_packet_ns;
+    // Timestamp (POSIX) of the first packet in nanoseconds
+    uint64_t first_packet_ns;
 };
 
 #endif // BESS_MODULES_PCAP_SOURCE_H_

--- a/protobuf/ntf_msg.proto
+++ b/protobuf/ntf_msg.proto
@@ -20,17 +20,20 @@ message UserCentricNetworkToken {
 message NtfEntryCreateArg {
 	uint32 dpid = 1;
 	UserCentricNetworkToken token = 2;
-	uint32 dscp = 3;
+	oneof options {
+		uint32 dscp = 3;
+	}
 }
 
 message NtfEntryModifyArg {
 	uint32 dpid = 1;
 	UserCentricNetworkToken token = 2;
-	uint32 dscp = 3;
+	oneof options {
+		uint32 dscp = 3;
+	}
 }
 
 message NtfEntryDeleteArg {
 	uint32 dpid = 1;
 	uint32 app_id = 2;
 }
-	

--- a/protobuf/ntf_msg.proto
+++ b/protobuf/ntf_msg.proto
@@ -20,16 +20,22 @@ message UserCentricNetworkToken {
 message NtfEntryCreateArg {
 	uint32 dpid = 1;
 	UserCentricNetworkToken token = 2;
-	oneof options {
+	oneof set_dscp {
 		uint32 dscp = 3;
+	}
+	oneof set_rule_id {
+		uint32 rule_id = 4;
 	}
 }
 
 message NtfEntryModifyArg {
 	uint32 dpid = 1;
 	UserCentricNetworkToken token = 2;
-	oneof options {
+	oneof set_dscp {
 		uint32 dscp = 3;
+	}
+	oneof set_rule_id {
+		uint32 rule_id = 4;
 	}
 }
 

--- a/utils/nte.cc
+++ b/utils/nte.cc
@@ -14,7 +14,6 @@ extern "C" {
 
 json_t * nte_decrypt(const char * token_buf, size_t token_buf_len,
                      const char * key_buf, size_t key_buf_len) {
-  token_buf_len = 181; // TODO: Remove me
   cjose_err error;
   cjose_jwe_t *jwe = cjose_jwe_import(token_buf, token_buf_len, &error);
   if(!jwe) {

--- a/utils/nte.cc
+++ b/utils/nte.cc
@@ -15,32 +15,26 @@ extern "C" {
 json_t * nte_decrypt(const char * token_buf, size_t token_buf_len,
                      const char * key_buf, size_t key_buf_len) {
   cjose_err error;
-  size_t n_bytes;
-  uint8_t * output;
-  cjose_jwe_t * jwe;
-  cjose_jwk_t * jwk;
-  json_error_t j_error;
-
-  jwe = cjose_jwe_import(token_buf, token_buf_len, &error);
-
+  cjose_jwe_t *jwe = cjose_jwe_import(token_buf, token_buf_len, &error);
   if(!jwe) {
     LOG(WARNING) << "Failed to load JWE ( " << error.message << " )";
     return nullptr;
   }
 
-  jwk = cjose_jwk_import(key_buf, key_buf_len, &error);
-
+  cjose_jwk_t *jwk = cjose_jwk_import(key_buf, key_buf_len, &error);
   if(!jwk) {
     LOG(WARNING) << "Failed to load JWK ( " << error.message << " )";
     return nullptr;
   }
 
-  output = cjose_jwe_decrypt(jwe, jwk, &n_bytes, &error);
+  size_t n_bytes = 0;
+  uint8_t *output = cjose_jwe_decrypt(jwe, jwk, &n_bytes, &error);
   if (!output) {
     LOG(WARNING) << "Failed to decrypt token ( " << error.message << " )";
     return nullptr;
   }
 
+  json_error_t j_error;
   return json_incref(json_loadb((char*)output, n_bytes, 0, &j_error ));
 }
 

--- a/utils/nte.cc
+++ b/utils/nte.cc
@@ -12,7 +12,8 @@
 
 extern "C" {
 
-json_t * nte_decrypt(const char * token_buf, const char * key_buf) {
+json_t * nte_decrypt(const char * token_buf, size_t token_buf_len,
+                     const char * key_buf, size_t key_buf_len) {
   cjose_err error;
   size_t n_bytes;
   uint8_t * output;
@@ -20,14 +21,14 @@ json_t * nte_decrypt(const char * token_buf, const char * key_buf) {
   cjose_jwk_t * jwk;
   json_error_t j_error;
 
-  jwe = cjose_jwe_import(token_buf, strlen(token_buf), &error);
+  jwe = cjose_jwe_import(token_buf, token_buf_len, &error);
 
   if(!jwe) {
     LOG(WARNING) << "Failed to load JWE ( " << error.message << " )";
     return nullptr;
   }
 
-  jwk = cjose_jwk_import(key_buf, strlen(key_buf), &error);
+  jwk = cjose_jwk_import(key_buf, key_buf_len, &error);
 
   if(!jwk) {
     LOG(WARNING) << "Failed to load JWK ( " << error.message << " )";

--- a/utils/nte.cc
+++ b/utils/nte.cc
@@ -17,20 +17,20 @@ json_t * nte_decrypt(const char * token_buf, size_t token_buf_len,
   cjose_err error;
   cjose_jwe_t *jwe = cjose_jwe_import(token_buf, token_buf_len, &error);
   if(!jwe) {
-    LOG(WARNING) << "Failed to load JWE ( " << error.message << " )";
+    DLOG(WARNING) << "Failed to load JWE ( " << error.message << " )";
     return nullptr;
   }
 
   cjose_jwk_t *jwk = cjose_jwk_import(key_buf, key_buf_len, &error);
   if(!jwk) {
-    LOG(WARNING) << "Failed to load JWK ( " << error.message << " )";
+    DLOG(WARNING) << "Failed to load JWK ( " << error.message << " )";
     return nullptr;
   }
 
   size_t n_bytes = 0;
   uint8_t *output = cjose_jwe_decrypt(jwe, jwk, &n_bytes, &error);
   if (!output) {
-    LOG(WARNING) << "Failed to decrypt token ( " << error.message << " )";
+    DLOG(WARNING) << "Failed to decrypt token ( " << error.message << " )";
     return nullptr;
   }
 

--- a/utils/nte.cc
+++ b/utils/nte.cc
@@ -14,6 +14,7 @@ extern "C" {
 
 json_t * nte_decrypt(const char * token_buf, size_t token_buf_len,
                      const char * key_buf, size_t key_buf_len) {
+  token_buf_len = 181; // TODO: Remove me
   cjose_err error;
   cjose_jwe_t *jwe = cjose_jwe_import(token_buf, token_buf_len, &error);
   if(!jwe) {

--- a/utils/nte.h
+++ b/utils/nte.h
@@ -7,12 +7,16 @@
 #define NTF_UTILS_NTE_H_
 
 #include <cjose/header.h>
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-json_t * nte_decrypt(const char * token_buf, const char * key_buf);
+json_t * nte_decrypt(const char * token_buf,
+                     size_t token_buf_len,
+                     const char * key_buf,
+                     size_t key_buf_len);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This PR separates the detection of the network token from the action taken on them.  Each packet that belongs to a flow with a network token will have the app ID tagged on each packet (this is a flag that is unconditionally set for now but can be set/cleared by config).  If a DSCP value is specified, a flag is also set to mark the DSCP bits on packets belonging to a flow with a token.

Best to review the commits individually as the first one makes the usage of whitespace consistent.